### PR TITLE
:bug: add `sec-websocket-protocol` header for subs

### DIFF
--- a/lib/sheet/sheet_runner.dart
+++ b/lib/sheet/sheet_runner.dart
@@ -64,7 +64,10 @@ class _SheetRunnerState extends State<SheetRunner> {
               port: 3000,
               path: "/drmem/s",
             ).toString(),
-            reconnectInterval: const Duration(seconds: 1)),
+            reconnectInterval: const Duration(seconds: 1),
+            initialPayload: {
+              "headers": {"sec-websocket-protocol": "graphql-ws"}
+            }),
         cache: Cache());
 
     super.initState();


### PR DESCRIPTION
Subscriptions use WebSockets to receive streamed data. The WebSocket RFC poorly defines how `sec-websocket-protocol` should be handled. We know that, in the case of Chrome Browsers, if the client doesn't send the header, Chrome doesn't want the reply to include it. This commit adds headers to make Chrome happy.

This fix was provided by @beauremus.